### PR TITLE
remove cve-2013-0156.rb (#1451)

### DIFF
--- a/config/initializers/cve-2013-0156.rb
+++ b/config/initializers/cve-2013-0156.rb
@@ -1,3 +1,0 @@
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::YAML)
-ActiveSupport::XmlMini::PARSING.delete("symbol")
-ActiveSupport::XmlMini::PARSING.delete("yaml")


### PR DESCRIPTION
remove cve-2013-0156.rb

https://github.com/errbit/errbit/pull/353
This vulnerability is found in Rails 3.x, not required in Rails 4.x